### PR TITLE
Fixed python extract tiles method

### DIFF
--- a/extracttiles.py
+++ b/extracttiles.py
@@ -3,38 +3,40 @@ import os
 import glob
 import pprint
 
-path = 'G:\\Program Files (x86)\\Steam\\steamapps\\common\\TaleSpire\\TaleSpire_Data\\Taleweaver\\boardAssets\\Tiles'
+#Assets are stored in a single file called index.json. Make sure to change the path to its location on your machine
+path = r'C:\Program Files (x86)\Steam\steamapps\common\TaleSpire\Taleweaver\d71427a1-5535-4fa7-82d7-4ca1e75edbfd\index.json'
 
 output = {}
 
-for root,d_names,f_names in os.walk(path):
-    #print(root, d_names, f_names)
-    for f in f_names:
-        #print(f)
-        if not f.endswith('boardAsset'):
-            continue
-        filename = os.path.join(root, f)
-        with open(filename, encoding='utf-8', mode='r') as currentFile:
-            currentFile.readline()
-            asset = json.loads(currentFile.read())
-            nguid = asset["GUID"]
-            asset_name = asset["boardAssetName"]
-            board_asset_group = asset["boardAssetGroup"]
-            width = 0
-            depth = 0
-            for tag in asset["Tags"]:
-                if "X" in tag:
-                    try:
-                        width = int(tag[:tag.index("X")])
-                        depth = int(tag[tag.index("X"):])
-                    except ValueError:
-                        print("Invalid tag with X")
-                        pass
-            height = asset["colliderBounds"][0]["m_Extent"]["y"]
-            if width == 0:
-                width = asset["assetLoaders"][0]["occluderInfo"]["Width"]
-            if depth == 0:
-                depth = asset["assetLoaders"][0]["occluderInfo"]["Depth"]
-            output[nguid] = {"name": asset_name, "group": board_asset_group, "width": width, "height": height, "depth": depth}
+with open(path, encoding='utf-8', mode='r') as currentFile:
+    assets = json.loads(currentFile.read())["Tiles"]
+    for asset in assets:
+        nguid = asset["Id"]
+        asset_name = asset["Name"]
+        board_asset_group = asset["GroupTag"]
+        width = 0
+        depth = 0
+
+        #Get width and height based on tag name (eg. 1x2)
+        for tag in asset["Tags"]:
+            tag = tag.lower()
+            if "x" in tag:
+                try:
+                    X_index = tag.index("x")
+                    
+                    width = int(tag[:X_index])
+                    depth = int(tag[X_index+1:])
+
+                    #print(f"Tag: {tag} width: {width} Height: {depth}")
+                except ValueError: 
+                    print(f"Invalid tag with X: {tag}")
+                    pass
+        if width == 0 or depth == 0:
+            raise RuntimeError(f'Width and Depth not specified in the index.json file for asset named: {asset_name}')
+            
+        height = asset["ColliderBoundsBound"]["m_Extent"]["y"]
+
+        output[nguid] = {"name": asset_name, "group": board_asset_group, "width": width, "height": height, "depth": depth}
+
 with open("assetdata.js", "w") as fout:
     fout.write("asset_data = " + json.dumps(output) + ";")


### PR DESCRIPTION
Fixed the python script that pulls the asset information. Assets are now stored in a single index.json file.  I checked to ensure that the html code still works and it successfully generates forest tiles with assets generated using this script. 